### PR TITLE
Remove dependency on file for test not yet implemented.

### DIFF
--- a/FitNesseRoot/HttpSuite/MethodNotAllowed/content.txt
+++ b/FitNesseRoot/HttpSuite/MethodNotAllowed/content.txt
@@ -13,8 +13,6 @@
 | script | http browser |
 | set host | localhost |
 | set port | 5000      |
-| put | /content.txt |
-| check | method not allowed response | true |
 | put | /file1 |
 | check | method not allowed response | true |
 | put | /file2 |


### PR DESCRIPTION
In the 405 test I have an assertion on a file that does not exist. The file is unnecessary for the test so I removed the assertion on that file within the group of the assertions in the test.
