### PR TITLE
Modifies DELETE Form Test to Ensure Data is Actually Deleted

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PostGetPutGet/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PostGetPutGet/content.txt
@@ -16,4 +16,6 @@
 |get     |/form                                 |
 |ensure  |body has content    |data = heathcliff|
 |delete  |/form                                 |
+|ensure  |response code equals|200              |
+|get     |/form                                 |
 |reject  |body has content    |data = heathcliff|


### PR DESCRIPTION
I was able to cheat this test because in my RequestRouter I never explicitly defined request uri of /form and request method of delete, and so it defaulted to going to my RootResponse where in the body data = heathcliff wasn't there, so the test passed.

I modified the test so that after requesting delete /form it ensures that the response code is 200, and requests the /form page again to ensure that it is deleted. 
