### PR TITLE
Fix bug in partial content test where it requests 5 bytes, but only chec...

### DIFF
--- a/fixtures/http_browser.rb
+++ b/fixtures/http_browser.rb
@@ -80,7 +80,7 @@ class HttpBrowser
 
   def body_has_partial_file_contents(file)
     contents = read_file(file)
-    response.body == contents[0..3]
+    response.body == contents[0..4]
   end
 
   def body_has_directory_contents(directory)


### PR DESCRIPTION
The partial content test requests a range of 0-4 (5 bytes) from the server.  However, when the response is received, the test only checks for 4 bytes returned (0-3).  The test can never pass.  I updated the test to check bytes 0-4 of the partial_content.txt file.
