### PR TITLE
User proper Allow. Strip spaces from method names

### DIFF
--- a/fixtures/http_browser.rb
+++ b/fixtures/http_browser.rb
@@ -62,8 +62,8 @@ class HttpBrowser
 
   def response_header_allow_contains(methods)
     expected_methods = methods.split(',')
-    response_allow_methods = response.headers["allow"].split(',')
-    expected_methods.all?{|method| response_allow_methods.include? method}
+    response_allow_methods = response.headers["Allow"].split(',')
+    expected_methods.all?{|method| response_allow_methods.include? method.strip}
   end
 
   def response_code_equals(code)


### PR DESCRIPTION
Previous implementation forced a return value of "allow: GET,HEAD,POST,OPTIONS,PUT"
