### PR TITLE
Prevent wiki formatting in test runner variables

### DIFF
--- a/FitNesseRoot/HttpTestSuite/content.txt
+++ b/FitNesseRoot/HttpTestSuite/content.txt
@@ -5,7 +5,7 @@
 
 !3 User-Defined Variables
 !define TEST_RUNNER {/path/to/rubyslim/bin/rubyslim}
--!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
--!define PUBLIC_DIR {/path/to/cob_spec/public/}
+!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
+!define PUBLIC_DIR {/path/to/cob_spec/public/}
 
 !contents -R2 -g -p -f -h

--- a/FitNesseRoot/HttpTestSuite/content.txt
+++ b/FitNesseRoot/HttpTestSuite/content.txt
@@ -4,8 +4,8 @@
 !path fixtures
 
 !3 User-Defined Variables
-!define TEST_RUNNER {/path/to/rubyslim/bin/rubyslim}
-!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
-!define PUBLIC_DIR {/path/to/cob_spec/public/}
+!define TEST_RUNNER {!- /path/to/rubyslim/bin/rubyslim -!}
+!define SERVER_START_COMMAND {!- java -jar /path/to/server.jar -!}
+!define PUBLIC_DIR {!- /path/to/cob_spec/public/ -!}
 
 !contents -R2 -g -p -f -h

--- a/fixtures/server.rb
+++ b/fixtures/server.rb
@@ -2,7 +2,7 @@ class Server
   attr_accessor :start_command, :port, :directory
 
   def start_server
-    @@pid = IO.popen("#{start_command} -p #{@port} -d #{@directory}").pid
+    @@pid = IO.popen("#{start_command} -p #{port} -d #{directory}").pid
     sleep(2)
   end
 


### PR DESCRIPTION
Hi there,

I ran into issues because my command variables were being parsed as wiki content:

> !define SERVER_START_COMMAND {java -cp /.../server.jar **ServerRunner**}

...ended up running as:

> java -cp /.../server.jar **ServerRunner &lt;a title="create page" href="HttpTestSuite.ServerRunner?edit&nonExistent=true"&gt;[?] &lt;/a&gt;**

I changed the example values to literals with `!- block-content -!`. Hopefully this will help newcomers prevent accidental formatting.
