### PR TITLE
Change basic auth test to check invalid auth

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/BasicAuth/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/BasicAuth/content.txt
@@ -1,20 +1,20 @@
 !-<i>The <code>/logs</code> url should be protected with <a href="http://www.w3.org/Protocols/HTTP/1.0/spec.html#BasicAA">basic access authentication</a>.
 A request passing username "admin" and password "hunter2" should return log information. All others should return a 401 Unauthorized response.</i>-!
 
-|script              |http browser                                         |
-|set host            |localhost                                            |
-|set port            |5000                                                 |
-|get                 |/logs                                                |
-|ensure              |response code equals      |401                       |
-|ensure              |body has content          |Authentication required   |
-|ensure              |body does not have content|GET /log HTTP/1.1         |
-|get                 |/log                                                 |
-|put                 |/these                                               |
-|head                |/requests                                            |
-|get with credentials|/logs                                                |
-|ensure              |response code equals      |200                       |
-|ensure              |body has content          |GET /log HTTP/1.1         |
-|ensure              |body has content          |PUT /these HTTP/1.1       |
-|ensure              |body has content          |HEAD /requests HTTP/1.1   |
+|script                      |http browser                                 |
+|set host                    |localhost                                    |
+|set port                    |5000                                         |
+|get with invalid credentials|/logs                                        |
+|ensure                      |response code equals |401                    |
+|ensure                      |body has content     |Authentication required|
+|ensure                      |body does not have content|GET /log HTTP/1.1 |
+|get                         |/log                                         |
+|put                         |/these                                       |
+|head                        |/requests                                    |
+|get with credentials        |/logs                                        |
+|ensure                      |response code equals|200                     |
+|ensure                      |body has content    |GET /log HTTP/1.1       |
+|ensure                      |body has content    |PUT /these HTTP/1.1     |
+|ensure                      |body has content    |HEAD /requests HTTP/1.1 |
 
 !contents -R2 -g -p -f -h

--- a/fixtures/http_browser.rb
+++ b/fixtures/http_browser.rb
@@ -16,6 +16,12 @@ class HttpBrowser
     response_present?
   end
 
+  def get_with_invalid_credentials(url)
+    encoded_auth = Base64.encode64("foo:bar")
+    @response = HTTParty.get("http://#{host}:#{port}#{url}", :headers => {"Authorization" => "Basic #{encoded_auth}"});
+    response_present?
+  end
+
   def get_with_credentials(url)
     encoded_auth = Base64.encode64("admin:hunter2")
     @response = HTTParty.get("http://#{host}:#{port}#{url}", :headers => {"Authorization" => "Basic #{encoded_auth}"});


### PR DESCRIPTION
The current basic BasicAuth test only checks for the presence of the Authorization header. This branch adds a method that will send invalid credentials to the server, and check to see if the server is properly authorizing requests.
