### PR TITLE
Add SimpleHead test

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/content.txt
@@ -1,0 +1,7 @@
+|script  |http browser                            |
+|set host|localhost                               |
+|set port|5000                                    |
+|head    |/file1                                  |
+|ensure  |response code equals |200               |
+|check   |header field value   |Content-Length| 14| 
+|ensure  |body has no content                     |

--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/properties.xml
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test/>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/fixtures/http_browser.rb
+++ b/fixtures/http_browser.rb
@@ -98,6 +98,10 @@ class HttpBrowser
     File.open(file, 'rb') { |f| f.read }
   end
 
+  def body_has_no_content
+    response.body.nil?
+  end
+
   def body_has_file_contents(file)
     contents = read_file(file)
     response.body.include? contents


### PR DESCRIPTION
This branch adds a simple head request test. The test sends a Head request for /file1, and checks if a content length header is returned without sending the response body.