### PR TITLE
Removes dashes preventing variables to be defined

### DIFF
--- a/FitNesseRoot/HttpTestSuite/content.txt
+++ b/FitNesseRoot/HttpTestSuite/content.txt
@@ -5,7 +5,7 @@
 !path target/Fixtures-1.0.jar
 
 !3 User-Defined Variables
--!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
--!define PUBLIC_DIR {/path/to/cob_spec/public/}
+!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
+!define PUBLIC_DIR {/path/to/cob_spec/public/}
 
 !contents -R2 -g -p -f -h


### PR DESCRIPTION
Removes the dashes before the variables that should be configured because they are preventing them to be defined.

If those should be kept, there's nothing mentioning that they should be removed it in the [README][readme].

[readme]: https://github.com/8thlight/cob_spec#configuring-cob-spec