### PR TITLE
Fixes misinformation in configuration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Open your browser and go to http://localhost:9090. You should see the Cob Spec w
 
 Configuring Cob Spec
 -------------------
-To run the tests you have to change three variables.
+To run the tests you have to change some variables.
 
 - Navigate to the HttpTestSuite.
 - Click on Edit.


### PR DESCRIPTION
The instructions to configure Cob Spec mention 3 variables that have to be changed, but only 2 are listed.

Changes the text to an indeterminate number to avoid confusion.