### PR TITLE
Because the test deletes the resource, the initial get should return …

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PostGetPutGetDeleteGet/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PostGetPutGetDeleteGet/content.txt
@@ -2,7 +2,7 @@
 |set host|localhost                             |
 |set port|5000                                  |
 |get     |/form                                 |
-|ensure  |response code equals|200              |
+|ensure  |response code equals|404              |
 |reject  |body has content    |data=fatcat     |
 |set data|data=fatcat                            |
 |post    |/form                                 |
@@ -18,4 +18,5 @@
 |delete  |/form                                 |
 |ensure  |response code equals|200              |
 |get     |/form                                 |
+|ensure  |response code equals|404              |
 |reject  |body has content    |data=heathcliff|


### PR DESCRIPTION
…a 404 - Not Found. Similarly, the final get should return a 404