### PR TITLE
Basic auth response header

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/BasicAuth/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/BasicAuth/content.txt
@@ -6,7 +6,7 @@ A request passing username "admin" and password "hunter2" should return log info
 |set port            |5000                                        |
 |get                 |/logs                                       |
 |ensure              |response code equals|401                    |
-|ensure              |body has content    |Authentication required|
+|ensure              |has basic auth                              |
 |reject              |body has content    |GET /log HTTP/1.1      |
 |get                 |/log                                        |
 |put                 |/these                                      |

--- a/src/main/java/HttpBrowser.java
+++ b/src/main/java/HttpBrowser.java
@@ -1,5 +1,6 @@
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.HiddenFileFilter;
+import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -160,6 +161,12 @@ public class HttpBrowser {
 
         return true;
     }
+
+    public boolean hasBasicAuth() {
+	Header authTypeHeader = response.getFirstHeader(HttpHeaders.WWW_AUTHENTICATE);
+	return authTypeHeader != null && authTypeHeader.getValue().contains(AuthSchemes.BASIC);
+    }
+
 
     private void storeResponseInfoFrom(HttpResponse response) throws IOException {
         this.response = response;


### PR DESCRIPTION
When no credentials are provided, a WWW-Authenticate header should be added with the value Basic.