### PR TITLE
MethodNotAllowed test enforces whitelisting

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/MethodNotAllowed/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/MethodNotAllowed/content.txt
@@ -1,7 +1,15 @@
-|script  |http browser            |
-|set host|localhost               |
-|set port|5000                    |
-|put     |/file1                  |
-|ensure  |response code equals|405|
-|post    |/text-file.txt          |
-|ensure  |response code equals|405|
+|script        |http browser                |
+|set host      |localhost                   |
+|set port      |5000                        |
+|get           |/file1                      |
+|ensure        |response code equals  | 200 |
+|put           |/file1                      |
+|ensure        |response code equals  | 405 |
+|bogus Request |/file1                      |
+|ensure        |response code equals  | 405 |
+|get           |/text-file.txt              |
+|ensure        |response code equals  | 200 |
+|post          |/text-file.txt              |
+|ensure        |response code equals  | 405 |
+|bogus Request |/file1                      |
+|ensure        |response code equals  | 405 |

--- a/src/main/java/HttpBrowser.java
+++ b/src/main/java/HttpBrowser.java
@@ -12,6 +12,7 @@ import util.Http;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -74,6 +75,11 @@ public class HttpBrowser {
     public void options(String url) throws IOException {
         Http browser = new Http(host, port);
         storeResponseInfoFrom(browser.options(url));
+    }
+
+    public void bogusRequest(String url) throws IOException, URISyntaxException {
+        Http browser = new Http(host, port);
+        storeResponseInfoFrom(browser.bogusRequest(url));
     }
 
     public void getRangeStartRangeEnd(String url, String start, String end) throws IOException {

--- a/src/main/java/util/BogusRequest.java
+++ b/src/main/java/util/BogusRequest.java
@@ -1,0 +1,35 @@
+package util;
+
+import org.apache.http.client.methods.*;
+import org.apache.http.ProtocolVersion;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Random;
+
+public class BogusRequest extends HttpRequestBase {
+    private final String PROTOCOL = "HTTP";
+
+    private final URI uri;
+    private final ProtocolVersion protocolVersion;
+
+    public BogusRequest(String uri) throws URISyntaxException {
+        this.uri = new URI(uri);
+        this.protocolVersion = new ProtocolVersion(PROTOCOL, 1, 1);
+    }
+
+    public String getMethod() {
+        String randomMethod = "";
+        Random r = new Random();
+        for(int i=0; i<8; i++)
+            randomMethod += (char)(r.nextInt(26) + 'A');
+        return randomMethod;
+    }
+  
+    public URI getURI() {
+        return uri;
+    }
+
+    public ProtocolVersion getProtocolVersion() {
+        return protocolVersion;
+    }
+}

--- a/src/main/java/util/Http.java
+++ b/src/main/java/util/Http.java
@@ -10,6 +10,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 
 public class Http {
     private final String host;
@@ -53,6 +54,10 @@ public class Http {
 
     public HttpResponse options(String url) throws IOException {
         return makeStandardRequest(new HttpOptions(fullUrlFrom(url)));
+    }
+
+    public HttpResponse bogusRequest(String url) throws IOException, URISyntaxException {
+        return makeStandardRequest(new BogusRequest(fullUrlFrom(url)));
     }
 
     public HttpResponse getWithPartialHeader(String url, String range) throws IOException {


### PR DESCRIPTION
- Instead of testing specific routes (which may encourage blacklisting
  routes), the test generates a request with a bogus, random method.

@KevinLiddle @dougbradbury 
As mentioned during our IPM, the 'execute' method of a request expects an HttpRequestBase (which only allows GET, PUT, POST, etc). 'Execute' has an overloaded method that accepts a HttpUriRequest which BogusRequest implements. The only purpose of BogusRequest is to generate a request with a bogus, randomized method name. 

The test checks:
- Response code 200 with GET (since the resources are located in the public folder)
- Response code 405 for PUT/POST (original tests. I leave them in so that people will not create logic that looks like "if (!Http.Methods.Contains(method)) { return 405; }")
- Response code 405 for bogusRequest (forces a whitelist approach)