### PR TITLE
FIX: the check for the content is missing the (s) in /logs

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/BasicAuth/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/BasicAuth/content.txt
@@ -7,13 +7,13 @@ A request passing username "admin" and password "hunter2" should return log info
 |get                 |/logs                                       |
 |ensure              |response code equals|401                    |
 |ensure              |has basic auth                              |
-|reject              |body has content    |GET /log HTTP/1.1      |
-|get                 |/log                                        |
+|reject              |body has content    |GET /logs HTTP/1.1     |
+|get                 |/logs                                       |
 |put                 |/these                                      |
 |head                |/requests                                   |
 |get with credentials|/logs                                       |
 |ensure              |response code equals|200                    |
-|ensure              |body has content    |GET /log HTTP/1.1      |
+|ensure              |body has content    |GET /logs HTTP/1.1     |
 |ensure              |body has content    |PUT /these HTTP/1.1    |
 |ensure              |body has content    |HEAD /requests HTTP/1.1|
 


### PR DESCRIPTION
This now matches the client request