### PR TITLE
Added Test for HTTP Head Method

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/content.txt
@@ -1,0 +1,11 @@
+!-<i>Head is an HTTP Method that only gets the response header with no body content.</i>-!
+
+| script | http browser |
+| set host | localhost |
+| set port | 5000      |
+| head | / |
+| ensure | response code equals | 200 |
+| ensure | body has no content |
+| head | /foobar |
+| ensure | response code equals | 404 |
+| ensure | body has no content |

--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/properties.xml
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleHead/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<properties>
+	<Edit>true</Edit>
+	<Files>true</Files>
+	<Properties>true</Properties>
+	<RecentChanges>true</RecentChanges>
+	<Refactor>true</Refactor>
+	<Search>true</Search>
+	<Test/>
+	<Versions>true</Versions>
+	<WhereUsed>true</WhereUsed>
+</properties>

--- a/src/main/java/HttpBrowser.java
+++ b/src/main/java/HttpBrowser.java
@@ -100,6 +100,10 @@ public class HttpBrowser {
         return latestResponseContentAsString().contains(content);
     }
 
+    public boolean bodyHasNoContent() throws IOException {
+        return latestResponseContentAsString().isEmpty();
+    }
+
     public boolean bodyHasFileContents(String filePath) throws IOException {
         byte[] fileContent = readBytesFromFile(filePath);
         return includes(fileContent, latestResponseContent);


### PR DESCRIPTION
Added a function that checks if the body has any content. Used when running the Simple Head Method, which tests whether the HTTP head method response has no body content and only the appropriate header. Tries head on a few different routes.