### PR TITLE
Updated method_options to always include HEAD with GET

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleOption/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleOption/content.txt
@@ -13,8 +13,8 @@ basic methods: GET,HEAD,POST,OPTIONS,PUT.</i>-!
 |head                |/method_options                                           |
 |options             |/method_options2                                          |
 |ensure              |response code equals           |200                       |
-|ensure              |response header allow contains |GET,OPTIONS               |
-|reject              |response header allow contains |HEAD,POST,PUT             |
+|ensure              |response header allow contains |GET,OPTIONS,HEAD          |
+|reject              |response header allow contains |POST,PUT                  |
 |get                 |/method_options2                                          |
 |options             |/method_options2                                          |
 

--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleOption/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimpleOption/content.txt
@@ -14,7 +14,8 @@ basic methods: GET,HEAD,POST,OPTIONS,PUT.</i>-!
 |options             |/method_options2                                          |
 |ensure              |response code equals           |200                       |
 |ensure              |response header allow contains |GET,OPTIONS,HEAD          |
-|reject              |response header allow contains |POST,PUT                  |
+|reject              |response header allow contains |POST                      |
+|reject              |response header allow contains |PUT                       |
 |get                 |/method_options2                                          |
 |options             |/method_options2                                          |
 


### PR DESCRIPTION
As @kevinkotowski noted [here](https://github.com/8thlight/cob_spec/pull/45#issuecomment-223122862) HEAD depends on GET, since one might have to hard code behavior to pass my previous test, it defeats the purpose. The quick fix here, is just moving HEAD to the allowed methods, while keeping the dynamic header by not allowing POST, and PUT.
