### PR TITLE
Update the Partial Content Spec

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PartialContent/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PartialContent/content.txt
@@ -3,10 +3,16 @@
 |set port|5000                                                                          |
 |get     |/partial_content.txt          |range start               |0   |range end|4    |
 |ensure  |response code equals          |206                                            |
+|check   |content range                 |bytes 0-4/77                                   |
 |ensure  |body has partial file contents|public/partial_content.txt|from|0        |to|4 |
 |get     |/partial_content.txt          |range start               |    |range end|6    |
 |ensure  |response code equals          |206                                            |
+|check   |content range                 |bytes 71-76/77                                 |
 |ensure  |body has partial file contents|public/partial_content.txt|from|71       |to|76|
 |get     |/partial_content.txt          |range start               |4   |range end|     |
 |ensure  |response code equals          |206                                            |
+|check   |content range                 |bytes 4-76/77                                  |
 |ensure  |body has partial file contents|public/partial_content.txt|from|4        |to|76|
+|get     |/partial_content.txt          |range start               |75  |range end|80   |
+|ensure  |response code equals          |416                                            |
+|check   |content range                 |bytes */77                                     |

--- a/src/main/java/HttpBrowser.java
+++ b/src/main/java/HttpBrowser.java
@@ -154,7 +154,7 @@ public class HttpBrowser {
     }
 
     public String location() {
-        return getHeaderValueFor("location");
+        return getHeaderValueFor(HttpHeaders.LOCATION);
     }
 
     public String contentRange() {

--- a/src/main/java/HttpBrowser.java
+++ b/src/main/java/HttpBrowser.java
@@ -154,9 +154,17 @@ public class HttpBrowser {
     }
 
     public String location() {
-        Header locationHeader = response.getFirstHeader("location");
+        return getHeaderValueFor("location");
+    }
 
-        return (locationHeader != null) ? locationHeader.getValue() : "";
+    public String contentRange() {
+        return getHeaderValueFor(HttpHeaders.CONTENT_RANGE);
+    }
+
+    private String getHeaderValueFor(String name) {
+        Header header = response.getFirstHeader(name);
+
+        return (header != null) ? header.getValue() : "";
     }
 
     public boolean responseHeaderAllowContains(String csvAllows) {
@@ -180,8 +188,8 @@ public class HttpBrowser {
     }
 
     public boolean hasBasicAuth() {
-	Header authTypeHeader = response.getFirstHeader(HttpHeaders.WWW_AUTHENTICATE);
-	return authTypeHeader != null && authTypeHeader.getValue().contains(AuthSchemes.BASIC);
+        Header authTypeHeader = response.getFirstHeader(HttpHeaders.WWW_AUTHENTICATE);
+        return authTypeHeader != null && authTypeHeader.getValue().contains(AuthSchemes.BASIC);
     }
 
     public boolean contentTypeIs(String type) {


### PR DESCRIPTION
This updates the spec to ensure that an unsatisfiable range request is handled,
and that a `Content-Range` header is sent back to the client. 

The spec will now make a request for the range `bytes=75/80` to `partial_content.txt` which only has 77 bytes. It expects that the server will respond with `416 Range Not Satisfiable`.

[RFC 7233 - 416 Range Not Satisfiable](https://tools.ietf.org/html/rfc7233#section-4.4)

Additionally, the spec will now expect that all range requests are responded to with a `Content-Range` header included. However, according to RFC 7233, it is not required that a `Content-Range` header is present.

[RFC 7233 - Content-Range](https://tools.ietf.org/html/rfc7233#section-4.2)
## New Partial Content Test Output
### All passing

<img width="400" alt="screen shot 2016-09-14 at 9 56 29 am" src="https://cloud.githubusercontent.com/assets/4121849/18518052/1438849a-7a64-11e6-9df1-02f1bbbed09b.png">
#### With incorrect Content-Range headers

<img width="400" alt="screen shot 2016-09-14 at 10 00 44 am" src="https://cloud.githubusercontent.com/assets/4121849/18518051/1434498e-7a64-11e6-8873-c0bc1b074ee7.png">
