### PR TITLE
Allow spaces after commas in Allows header

### DIFF
--- a/src/main/java/HttpBrowser.java
+++ b/src/main/java/HttpBrowser.java
@@ -160,9 +160,9 @@ public class HttpBrowser {
     }
 
     public boolean responseHeaderAllowContains(String csvAllows) {
-        String[] allows = csvAllows.split(",");
+        String[] allows = csvAllows.split(", *");
         Header responseAllows = response.getFirstHeader(HttpHeaders.ALLOW);
-        String[] serverAllows = responseAllows.getValue().split(",");
+        String[] serverAllows = responseAllows.getValue().split(", *");
 
         for (String  allow : allows) {
             boolean containsString = false;


### PR DESCRIPTION
Example in HTTP/1.1 spec actually has spaces after the commas in the list of allowed methods. Regex changed to split on either "," or ", ".
