### PR TITLE
Improve ResponseTestSuite.PostGetPutGetDeleteGet

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PostGetPutGetDeleteGet/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/PostGetPutGetDeleteGet/content.txt
@@ -1,21 +1,21 @@
-|script  |http browser                          |
-|set host|localhost                             |
-|set port|5000                                  |
-|get     |/form                                 |
-|ensure  |response code equals|200              |
-|reject  |body has content    |data=fatcat     |
-|set data|data=fatcat                            |
-|post    |/form                                 |
-|ensure  |response code equals|200              |
-|get     |/form                                 |
-|ensure  |response code equals|200              |
-|ensure  |body has content    |data=fatcat     |
-|set data|data=heathcliff                       |
-|put     |/form                                 |
-|ensure  |response code equals|200              |
-|get     |/form                                 |
-|ensure  |body has content    |data=heathcliff|
-|delete  |/form                                 |
-|ensure  |response code equals|200              |
-|get     |/form                                 |
-|reject  |body has content    |data=heathcliff|
+|script  |http browser                         |
+|set host|localhost                            |
+|set port|5000                                 |
+|get     |/form/feline                         |
+|ensure  |response code equals |404            |
+|set data|data=fatcat                          |
+|post    |/form                                |
+|ensure  |response code equals |201            |
+|check   |location|/form/feline                |
+|get     |/form/feline                         |
+|ensure  |response code equals |200            |
+|ensure  |body has content     |data=fatcat    |
+|set data|data=heathcliff                      |
+|put     |/form/feline                         |
+|ensure  |response code equals |200            |
+|get     |/form/feline                         |
+|ensure  |body has content     |data=heathcliff|
+|delete  |/form/feline                         |
+|ensure  |response code equals |200            |
+|get     |/form/feline                         |
+|ensure  |response code equals |404            |

--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimplePost/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimplePost/content.txt
@@ -2,5 +2,5 @@
 |set host|localhost               |
 |set port|5000                    |
 |set data|"My"="Data"             |
-|post    |/form                   |
+|post    |/noop-form              |
 |ensure  |response code equals|200|

--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimplePut/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimplePut/content.txt
@@ -1,6 +1,10 @@
-|script  |http browser            |
-|set host|localhost               |
-|set port|5000                    |
-|set data|"My"="Data"             |
-|put     |/form                   |
-|ensure  |response code equals|200|
+|script  |http browser                    |
+|set host|localhost                       |
+|set port|5000                            |
+|set data|"My"="Data"                     |
+|put     |/form/feline                    |
+|ensure  |response code equals|201        |
+|get     |/form/feline                    |
+|ensure  |response code equals|200        |
+|ensure  |body has content    |"My"="Data"|
+|delete  |/form/feline                    |

--- a/FitNesseRoot/HttpTestSuite/content.txt
+++ b/FitNesseRoot/HttpTestSuite/content.txt
@@ -5,7 +5,7 @@
 !path target/Fixtures-1.0.jar
 
 !3 User-Defined Variables
-!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
-!define PUBLIC_DIR {/path/to/cob_spec/public/}
+-!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
+-!define PUBLIC_DIR {/path/to/cob_spec/public/}
 
 !contents -R2 -g -p -f -h

--- a/FitNesseRoot/HttpTestSuite/content.txt
+++ b/FitNesseRoot/HttpTestSuite/content.txt
@@ -5,7 +5,7 @@
 !path target/Fixtures-1.0.jar
 
 !3 User-Defined Variables
--!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
--!define PUBLIC_DIR {/path/to/cob_spec/public/}
+!define SERVER_START_COMMAND {java -jar /path/to/server.jar}
+!define PUBLIC_DIR {/path/to/cob_spec/public/}
 
 !contents -R2 -g -p -f -h


### PR DESCRIPTION
The /form resource has some pretty odd properties including the power of resurrection.  Although I'm pretty sure nothing /form does is technically in violation of the HTTP specification, it is definitely not normal.

/form seems to be immortal, but its content is undefined when it hasn't been POST or PUT to or after it has been DELETED.  Also, there doesn't appear to be a difference between the PUT and POST behaviors.

I split /form into two resources: /form and /form/feline.  /form can now only POST and always writes it's contents to /form/feline which supports GET, PUT, and DELETE.  This also allows us to test the concept of sending a Location response header to point to the resource created by POST.