### PR TITLE
Poll for server availability in suite setup

### DIFF
--- a/FitNesseRoot/HttpTestSuite/SuiteSetUp/content.txt
+++ b/FitNesseRoot/HttpTestSuite/SuiteSetUp/content.txt
@@ -1,5 +1,6 @@
 |script           |Server                 |
 |set start command|${SERVER_START_COMMAND}|
+|set host         |localhost              |
 |set port         |5000                   |
 |set directory    |${PUBLIC_DIR}          |
 |start server                             |

--- a/src/main/java/Server.java
+++ b/src/main/java/Server.java
@@ -4,6 +4,7 @@ import java.net.Socket;
 public class Server {
     private String startCommand;
     private String directory;
+    private String host;
     private String port;
     static private Process process;
 
@@ -13,6 +14,10 @@ public class Server {
 
     public void setDirectory(String directory) {
         this.directory = directory;
+    }
+
+    public void setHost(String host) {
+      this.host = host;
     }
 
     public void setPort(String port) {
@@ -28,20 +33,26 @@ public class Server {
     }
 
     public boolean hostAvailable() {
-        Socket s = null;
+        Socket socket = null;
         try {
-            s = new Socket("0.0.0.0", Integer.parseInt(port));
+            socket = new Socket(host, Integer.parseInt(port));
             return true;
         } catch (IOException ex) {
             /* ignore */
         } finally {
-            try {
-                if (s != null) s.close();
-            } catch (IOException ex) {
-                /* ignore */
-            }
+          closeSocket(socket);
         }
         return false;
+    }
+
+    private void closeSocket(Socket socket) {
+        try {
+          if (socket != null) {
+              socket.close();
+          }
+        } catch (IOException ex) {
+            /* ignore */
+        }
     }
 
     public void stopServer() throws Exception {

--- a/src/main/java/Server.java
+++ b/src/main/java/Server.java
@@ -1,3 +1,6 @@
+import java.io.IOException;
+import java.net.Socket;
+
 public class Server {
     private String startCommand;
     private String directory;
@@ -19,7 +22,26 @@ public class Server {
     public void startServer() throws Exception {
         String command = startCommand + " -p " + port + " -d " + directory;
         process = Runtime.getRuntime().exec(command);
-        Thread.sleep(2000);
+        while (!hostAvailable()) {
+          Thread.sleep(2000);
+        }
+    }
+
+    public boolean hostAvailable() {
+        Socket s = null;
+        try {
+            s = new Socket("0.0.0.0", Integer.parseInt(port));
+            return true;
+        } catch (IOException ex) {
+            /* ignore */
+        } finally {
+            try {
+                if (s != null) s.close();
+            } catch (IOException ex) {
+                /* ignore */
+            }
+        }
+        return false;
     }
 
     public void stopServer() throws Exception {


### PR DESCRIPTION
Currently the test suite setup runs server start command and then sleeps for 2 seconds. This sleep time is a bit arbitrary and can cause test instability for servers with longer start up times.

Code change polls server socket to check availability before starting tests.

N.b. The exception handling is a bit ugly as it seems that we are using java version that doesn't support [try-with-resources ](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html). I'm not super familiar with Java so would be happy to get feedback on any better way of doing this.