### PR TITLE
fix-simple-put

### DIFF
--- a/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimplePut/content.txt
+++ b/FitNesseRoot/HttpTestSuite/ResponseTestSuite/SimplePut/content.txt
@@ -2,5 +2,5 @@
 |set host|localhost               |
 |set port|5000                    |
 |set data|"My"="Data"             |
-|put     |/form                   |
+|put     |/put-target             |
 |ensure  |response code equals|200|


### PR DESCRIPTION
This PR is for the **SimplePut** test.

If Cob Spec is expecting a `200 OK` response, that means the file already exists and it has been modified successfully (so since the request url is `/form`, that means a file named "form" should already exist in the Cob Spec public folder).

Here is what the server _should_ do when responding to a `PUT` request:

- If the file _doesn't_ exist:
  - Server creates a file with the correct contents, and sends a `201 Created` response
- Otherwise, if the file _does_ exist:
  - Server modifies the file, and sends either a `200 OK` or `204 No Content` response

Therefore, if Cob Spec is expecting a `200 OK` in response to the `PUT` request, then the file in the request url should already exist.

What I've done is to add a file called `put-form` to the Cob Spec public folder, as well as change the Cob Spec script to have `/put-form` as the request url.

Sources:
[RFC 7231 - PUT](https://tools.ietf.org/html/rfc7231#section-4.3.4)
[MDN PUT Documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/PUT
)