### PR TITLE
Add dependencies for cob spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ To test your server against the Cob Spec suite of tests, follow the instructions
 
     git clone git@github.com:8thlight/cob_spec.git
     cd cob_spec
-    mvn package
+    mvn package  
+  
+Setup
+------------
+
+Cob Spec requires maven and JDK 8 to be installed.  
 
 Starting Fitnesse Server
 ------------------------

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To test your server against the Cob Spec suite of tests, follow the instructions
 Setup
 ------------
 
-Cob Spec requires maven and JDK 8 to be installed.  
+Cob Spec requires [Maven](https://maven.apache.org/install.html) and [JDK 8](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) to be installed.  
 
 Starting Fitnesse Server
 ------------------------

--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@ Cob Spec
 ========
 Cob Spec is a suite of tests used to validate a web server to ensure it adheres to [HTTP specifications](https://tools.ietf.org/html/rfc7230). These acceptance tests were created using a testing suite called [FitNesse](http://fitnesse.org). FitNesse is an application testing suite that allows you to test the business layer of your application.
 
+Setup
+------------
+
+Cob Spec requires [Maven](https://maven.apache.org/install.html) and [JDK 8](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) to be installed to run correctly.  
+
+Getting Started
+----------------
+
 To test your server against the Cob Spec suite of tests, follow the instructions below.
 
     git clone git@github.com:8thlight/cob_spec.git
     cd cob_spec
     mvn package  
   
-Setup
-------------
-
-Cob Spec requires [Maven](https://maven.apache.org/install.html) and [JDK 8](https://docs.oracle.com/javase/8/docs/technotes/guides/install/install_overview.html) to be installed.  
-
 Starting Fitnesse Server
 ------------------------
 Start the Fitnesse server on port 9090.


### PR DESCRIPTION
Save people the debugging headache -  cob_spec expects you to have maven and JDK 8 installed