### PR TITLE
Feature/partial content suffix limit

### DIFF
--- a/FitNesseRoot/HttpTestSuite/FileServerTestSuite/PartialContent/content.txt
+++ b/FitNesseRoot/HttpTestSuite/FileServerTestSuite/PartialContent/content.txt
@@ -16,3 +16,7 @@
 |get     |/partial_content.txt          |range start               |10  |range end|0    |
 |ensure  |response code equals          |416                                            |
 |check   |content range                 |bytes */77                                     |
+|get     |/partial_content.txt          |range start               |75   |range end|80  |
+|ensure  |response code equals          |206                                            |
+|check   |content range                 |bytes 75-76/77                                  |
+|ensure  |body has partial file contents|public/partial_content.txt|from|75        |to|76|

--- a/FitNesseRoot/HttpTestSuite/FileServerTestSuite/PartialContent/content.txt
+++ b/FitNesseRoot/HttpTestSuite/FileServerTestSuite/PartialContent/content.txt
@@ -20,3 +20,10 @@
 |ensure  |response code equals          |206                                            |
 |check   |content range                 |bytes 75-76/77                                  |
 |ensure  |body has partial file contents|public/partial_content.txt|from|75        |to|76|
+|get     |/partial_content.txt          |range start               |  |range end|78    |
+|ensure  |response code equals          |206                                            |
+|check   |content range                 |bytes 0-76/77                                  |
+|ensure  |body has partial file contents|public/partial_content.txt|from|0        |to|76|
+|get     |/partial_content.txt          |range start               |77|range end|    |
+|ensure  |response code equals          |416                                            |
+|check   |content range                 |bytes */77                                     |

--- a/FitNesseRoot/HttpTestSuite/FileServerTestSuite/PartialContent/content.txt
+++ b/FitNesseRoot/HttpTestSuite/FileServerTestSuite/PartialContent/content.txt
@@ -13,6 +13,6 @@
 |ensure  |response code equals          |206                                            |
 |check   |content range                 |bytes 4-76/77                                  |
 |ensure  |body has partial file contents|public/partial_content.txt|from|4        |to|76|
-|get     |/partial_content.txt          |range start               |75  |range end|80   |
+|get     |/partial_content.txt          |range start               |10  |range end|0    |
 |ensure  |response code equals          |416                                            |
 |check   |content range                 |bytes */77                                     |


### PR DESCRIPTION
Modify PartialContent to expect wrapping of range requests

> Resolves #72

Plus, add tests for unsatisfiable range requests:

**Added**:
- Start position out of bounds -> 416
- Start position greater than last position -> 416
- Suffix range (`-X`) greater than file length -> 206 w/ entire file

**Modified**:
- GET range `X-Y` where `Y` beyond end of file  -> 206 with last position at end of file
  - Previously expected 416, which doesn't match HTTP range request spec