### PR TITLE
Expect 501 status code for "bogus" request

### DIFF
--- a/FitNesseRoot/HttpTestSuite/FileServerTestSuite/MethodNotAllowed/content.txt
+++ b/FitNesseRoot/HttpTestSuite/FileServerTestSuite/MethodNotAllowed/content.txt
@@ -6,4 +6,4 @@
 |post          |/file1                      |
 |ensure        |response code equals  | 405 |
 |bogus Request |/file1                      |
-|ensure        |response code equals  | 405 |
+|ensure        |response code equals  | 400 |

--- a/FitNesseRoot/HttpTestSuite/FileServerTestSuite/MethodNotAllowed/content.txt
+++ b/FitNesseRoot/HttpTestSuite/FileServerTestSuite/MethodNotAllowed/content.txt
@@ -6,4 +6,4 @@
 |post          |/file1                      |
 |ensure        |response code equals  | 405 |
 |bogus Request |/file1                      |
-|ensure        |response code equals  | 400 |
+|ensure        |response code equals  | 501 |


### PR DESCRIPTION
RFC 7320 Section 3.1.1 (Request Line) states:

> Recipients of an invalid request-line SHOULD respond with either a 400 (Bad Request) error or a 301 (Moved Permanently) redirect with the request-target properly encoded

Valid methods are defined here: https://tools.ietf.org/pdf/rfc7231.pdf#section-4

Therefore, cob_spec's "Bogus Request" should result in a 400, not 405.