### PR TITLE
Ensure that server is started in Setup and allow timeout to be config…

### DIFF
--- a/FitNesseRoot/HttpTestSuite/SuiteSetUp/content.txt
+++ b/FitNesseRoot/HttpTestSuite/SuiteSetUp/content.txt
@@ -3,3 +3,4 @@
 |set port         |5000                   |
 |set directory    |${PUBLIC_DIR}          |
 |start server                             |
+|ensure   |server is started within |PT10S|

--- a/src/main/java/Server.java
+++ b/src/main/java/Server.java
@@ -1,3 +1,10 @@
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.LocalTime;
+
 public class Server {
     private String startCommand;
     private String directory;
@@ -19,10 +26,29 @@ public class Server {
     public void startServer() throws Exception {
         String command = startCommand + " -p " + port + " -d " + directory;
         process = Runtime.getRuntime().exec(command);
-        Thread.sleep(2000);
     }
 
-    public void stopServer() throws Exception {
+    public boolean serverIsStartedWithin(String timeout) {
+        LocalTime abortTime = LocalTime.now().plus(Duration.parse(timeout));
+        while (LocalTime.now().isBefore(abortTime)) {
+            if (isServerListeningOn(Integer.parseInt(this.port)))
+                return true;
+        }
+        return false;
+    }
+
+    private boolean isServerListeningOn(int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", port), 1000);
+            return true;
+        } catch (UnknownHostException e) {
+            throw new IllegalArgumentException(e);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    public void stopServer() {
         process.destroy();
     }
 }


### PR DESCRIPTION
…urable.

I had an issue where the test suite was not working because my server took more than 2 seconds to start. I investigated and saw that it is possible to add a check to ensure the server is really started in the setup phase.

Therefore, I added an `ensure` step in the Setup phase to:
1. Allow the test to continue base on when the server was started
2. Allow the timeout for the check to be configurable, using [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) notation
